### PR TITLE
#2 

### DIFF
--- a/src/Cosmos.Entity.Mapper.csproj
+++ b/src/Cosmos.Entity.Mapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <MinVerTagPrefix>v</MinVerTagPrefix>
-    <Version>1.0.0-rc2.0.0</Version>
+    <Version>1.0.0</Version>
     <Features>strict</Features>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>A simple entity wrapper for Microsoft's cosmos database. Allows ease of use by exposing collections through a unit of work and repository pattern</Description>

--- a/src/Cosmos.Entity.Mapper.xml
+++ b/src/Cosmos.Entity.Mapper.xml
@@ -364,6 +364,18 @@
             </remarks>
             <returns></returns>
         </member>
+        <member name="M:Cosmos.Entity.Mapper.Extensions.QueryableExtensions.OrderByDynamicProperty``1(System.Linq.IQueryable{``0},System.String,System.Nullable{System.ComponentModel.ListSortDirection})">
+            <summary>
+            Performs a dynamic order by on <paramref name="property"/> using <paramref name="direction"/> to determine the sort order
+            </summary>
+            <typeparam name="TDocument"></typeparam>
+            <param name="source"></param>
+            <param name="property"></param>
+            <param name="direction"></param>
+            <returns></returns>
+            <exception cref="T:System.InvalidOperationException"></exception>
+            <exception cref="T:System.ArgumentNullException"></exception>
+        </member>
         <member name="T:Cosmos.Entity.Mapper.Extensions.TaskExtensions">
             <summary>
             This is an internal API that supports the Cosmos Entity Mapper core infrastructure and not subject to the same compatibility

--- a/src/Extensions/QueryableExtensions.cs
+++ b/src/Extensions/QueryableExtensions.cs
@@ -1,4 +1,9 @@
-﻿using System.Linq;
+﻿using Cosmos.Entity.Mapper.Utilities;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Cosmos.Entity.Mapper.Extensions
 {
@@ -45,6 +50,30 @@ namespace Cosmos.Entity.Mapper.Extensions
             byte pageOffset = 1;
             return query.Skip(((int)page - pageOffset) * (int)pageSize)
                 .Take((int)pageSize);
+        }
+
+        /// <summary>
+        /// Performs a dynamic order by on <paramref name="property"/> using <paramref name="direction"/> to determine the sort order
+        /// </summary>
+        /// <typeparam name="TDocument"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="property"></param>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static IOrderedQueryable<TDocument> OrderByDynamicProperty<TDocument>(this IQueryable<TDocument> source, string property, ListSortDirection? direction = null)
+        {
+            EntityValidationBase.NotNullOrThrow(source);
+            EntityValidationBase.NotNullOrThrow(property);
+            var propertyInstance = typeof(TDocument).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(e => e.Name.Equals(property, StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault() ?? throw new InvalidOperationException($"{property} is not supported");
+            var leftParam = Expression.Parameter(source.ElementType, "arg");
+            MemberExpression memberExpression = Expression.Property(leftParam, propertyInstance.Name);
+            string sortmethod = direction is not null ? (direction == ListSortDirection.Ascending ? "OrderBy" : "OrderByDescending") : "OrderBy";
+            MethodCallExpression expression = Expression.Call(typeof(Queryable), sortmethod, new Type[] { source.ElementType, memberExpression.Type }, source.Expression, Expression.Quote(Expression.Lambda(memberExpression, leftParam)));
+            return source.Provider.CreateQuery(expression) as IOrderedQueryable<TDocument>;
         }
     }
 }

--- a/tests/Cosmos.Entity.Mapper.Tests/Extensions/QueryableExtensionsTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/Extensions/QueryableExtensionsTests.cs
@@ -1,6 +1,8 @@
-﻿using Bogus;
+﻿using Cosmos.Entity.Mapper.Extensions;
+using Bogus;
 using NUnit.Framework;
 using System.Linq;
+using System;
 
 namespace Cosmos.Entity.Mapper.Extensions.Tests
 {
@@ -23,6 +25,45 @@ namespace Cosmos.Entity.Mapper.Extensions.Tests
             var firstTen = stub.Take(10);
             var actual = stub.PaginateByOffset(0, 10).ToList();
             Assert.That(firstTen, Is.EquivalentTo(actual));
+        }
+
+        public class DynamicPropertyTest
+        {
+            public int Prop1 { get; set; }
+        }
+
+        [Test()]
+        public void OrderByDynamicProperty_Can_Throw_Exception_When_Property_Does_Not_Exist_In_Entity()
+        {
+            var stub = new Faker<DynamicPropertyTest>()
+                .RuleFor(e => e.Prop1,e => e.UniqueIndex)
+                .Generate(10)
+                .AsQueryable();
+            Assert.Throws<InvalidOperationException>(() => stub.OrderByDynamicProperty("NoneExistingProperty", System.ComponentModel.ListSortDirection.Ascending));
+        }
+
+        [Test()]
+        public void OrderByDynamicProperty_Can_Order_Query_Using_Case_Insensitive_Property_Name()
+        {
+            var stub = new Faker<DynamicPropertyTest>()
+                .RuleFor(e => e.Prop1, e => e.UniqueIndex)
+                .Generate(10)
+                .AsQueryable();
+            var actual = stub.OrderByDynamicProperty("prop1", System.ComponentModel.ListSortDirection.Descending).FirstOrDefault();
+            var compare = stub.OrderByDescending(e => e.Prop1).FirstOrDefault();
+            Assert.That(actual, Is.EqualTo(compare));
+        }
+
+        [Test()]
+        public void OrderByDynamicProperty_Can_Order_Query_After_Where_Clause_IsApplied()
+        {
+            var stub = new Faker<DynamicPropertyTest>()
+                .RuleFor(e => e.Prop1, e => e.UniqueIndex)
+                .Generate(10)
+                .AsQueryable();
+            var actual = stub.Where(e => e.Prop1 != 0).OrderByDynamicProperty("Prop1", System.ComponentModel.ListSortDirection.Descending).FirstOrDefault();
+            var compare = stub.Where(e => e.Prop1 != 0).OrderByDescending(e => e.Prop1).FirstOrDefault();
+            Assert.That(actual, Is.EqualTo(compare));
         }
     }
 }


### PR DESCRIPTION
Added the `OrderByDynamicProperty` extension to the IQueryable group. Property name is case insensitive and did check the existence of the property name on the target entity.

This update will also bump the version to v1.0.0.