### PR TITLE
Converted AsEnumerableAsync to use async enumerator.

### DIFF
--- a/src/Cosmos.Entity.Mapper.csproj
+++ b/src/Cosmos.Entity.Mapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <MinVerTagPrefix>v</MinVerTagPrefix>
-    <Version>1.0.0</Version>
+    <Version>1.0.1-beta</Version>
     <Features>strict</Features>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>A simple entity wrapper for Microsoft's cosmos database. Allows ease of use by exposing collections through a unit of work and repository pattern</Description>
@@ -37,7 +37,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />

--- a/src/Cosmos.Entity.Mapper.xml
+++ b/src/Cosmos.Entity.Mapper.xml
@@ -410,10 +410,7 @@
             Provides a facade or an interface to actualize the query.
             </summary>
             <remarks>
-            <para>This was added to ease unit testing. The entity mapper depends on a lot extension methods to materialize queries. This can be
-            difficult to test. The <see cref="T:Cosmos.Entity.Mapper.IQueryMaterializable`1"/> interface provides the same methods thereby enabling developers to mock
-            the behavior of each method. Behind the scene, the methods calls the same extension methods you would otherwise use to materialize the query directly</para>
-            <para>If unit testing is a requirement for your team, this approach is highly recommended</para>
+            <para>This was added to prevent conflict in code base using EFCore because they share a lot of APIs </para>
             </remarks>
             <typeparam name="TDocument"></typeparam>
             <param name="source"></param>
@@ -434,16 +431,6 @@
             </summary>
             <param name="cancellationToken"></param>
             <param name="source"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Cosmos.Entity.Mapper.MaterializationExtensions.ToEnumerableAsync``1(System.Linq.IQueryable{``0},System.Threading.CancellationToken)">
-            <summary>
-            Actualizes the <see cref="T:System.Linq.IQueryable`1"/> to an enumerable and returns a list 
-            of <typeparamref name="TDocument"/>
-            </summary>
-            <typeparam name="TDocument"></typeparam>
-            <param name="source"></param>
-            <param name="cancellationToken"></param>
             <returns></returns>
         </member>
         <member name="M:Cosmos.Entity.Mapper.MaterializationExtensions.FirstOrDefaultAsync``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Threading.CancellationToken)">
@@ -655,7 +642,7 @@
         </member>
         <member name="M:Cosmos.Entity.Mapper.IQueryMaterializable`1.AsEnumerableAsync(System.Threading.CancellationToken)">
             <summary>
-            Actualizes the <see cref="T:System.Linq.IQueryable`1"/> to an enumerable and returns a list 
+            Provides a non-thread-blocking interface to materialize the queryable
             of <typeparamref name="TDocument"/>
             </summary>
             <param name="cancellationToken"></param>

--- a/src/IQueryMaterializable.cs
+++ b/src/IQueryMaterializable.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,12 +27,12 @@ namespace Cosmos.Entity.Mapper
         public abstract FeedIterator<TDocument> ToFeedIterator();
 
         /// <summary>
-        /// Actualizes the <see cref="IQueryable{T}"/> to an enumerable and returns a list 
+        /// Provides a non-thread-blocking interface to materialize the queryable
         /// of <typeparamref name="TDocument"/>
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public abstract Task<IEnumerable<TDocument>> AsEnumerableAsync(CancellationToken cancellationToken = default);
+        public abstract IAsyncEnumerable<TDocument> AsEnumerableAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Materializes the <see cref="IQueryExecutor{TDocument}"/> to a list

--- a/tests/Cosmos.Entity.Mapper.Tests/Attributes/CollectionDefinitionReaderTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/Attributes/CollectionDefinitionReaderTests.cs
@@ -26,7 +26,7 @@ namespace Cosmos.Entity.Mapper.Attributes.Tests
         {
             var definitionReader = new SchemaDefinitionReader<SomeEntityWithType>();
             bool actual = definitionReader.AttributeIsDefinedOnEntity<DocumentPartitionAttribute>();
-            Assert.True(actual);
+            Assert.That(actual, Is.True);
         }
 
         [Test()]

--- a/tests/Cosmos.Entity.Mapper.Tests/CollectionSetTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/CollectionSetTests.cs
@@ -24,7 +24,7 @@ namespace Cosmos.Entity.Mapper.Tests
         public void OfType_Can_Project_To_Derived_Object()
         {
             var collectionSet = new InternalCollectionSet<OfTypeBaseTestClass>(new Mock<Container>().Object, new ContextOptions { }).OfType<OfTypeDerivedClass>();
-            Assert.NotNull(collectionSet);
+            Assert.That(collectionSet, Is.Not.Null);
         }
     }
 }

--- a/tests/Cosmos.Entity.Mapper.Tests/Cosmos.Entity.Mapper.Tests.csproj
+++ b/tests/Cosmos.Entity.Mapper.Tests/Cosmos.Entity.Mapper.Tests.csproj
@@ -6,16 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Bogus" Version="35.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/tests/Cosmos.Entity.Mapper.Tests/Diagnostics/Logging/DiagnosticsLoggerTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/Diagnostics/Logging/DiagnosticsLoggerTests.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Entity.Mapper.Diagnostics.Logging.Tests
         public void Can_Create_Instance_Of_Logger_Factory_If_Non_Is_Assigned()
         {
             ILoggerFactory factory = DiagnosticsLogger.LoggerFactory;
-            Assert.NotNull(factory);
+            Assert.That(factory, Is.Not.Null);
         }
     }
 }

--- a/tests/Cosmos.Entity.Mapper.Tests/Extensions/EntityMapperExtensionsTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/Extensions/EntityMapperExtensionsTests.cs
@@ -11,8 +11,8 @@ namespace Cosmos.Entity.Mapper.Tests
         {
             var stub = Enumerable.Empty<string>().AsQueryable();
             var actual = stub.AsMaterializable();
-            Assert.NotNull(actual);
-            Assert.True(actual is IQueryMaterializable<string>);
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual is IQueryMaterializable<string>, Is.True);
         }
     }
 }

--- a/tests/Cosmos.Entity.Mapper.Tests/Internal/InternalCollectionSetTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/Internal/InternalCollectionSetTests.cs
@@ -38,7 +38,7 @@ namespace Cosmos.Entity.Mapper.Internal.Tests
 
             var collectionSet = new InternalCollectionSet<TestDocumentStub>(container.Object, new ContextOptions { });
             var actual = await collectionSet.FindAsync("id", "partitionKey", CancellationToken.None);
-            Assert.NotNull(actual);
+            Assert.That(actual, Is.Not.Null);
         }
 
         [Test()]

--- a/tests/Cosmos.Entity.Mapper.Tests/QueryMaterializerTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/QueryMaterializerTests.cs
@@ -16,7 +16,7 @@ namespace Cosmos.Entity.Mapper.Tests
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; }       
     }
 
     [TestFixture()]
@@ -27,7 +27,7 @@ namespace Cosmos.Entity.Mapper.Tests
 
 
         [Test()]
-        public async Task ToEnumerableAsync_Can_Return_An_Enumerable_Of_Entity_When_Queried_Against_A_Queryable()
+        public async Task ToListAsync_Can_Return_A_List_Of_Entities_When_Queried_Against_A_Queryable()
         {
             var stubs = new List<CollectionQueryableStub>
             {
@@ -44,7 +44,7 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
             collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
-            var actual = await collectionQueryableMock.Object.AsEnumerableAsync();
+            var actual = await collectionQueryableMock.Object.ToListAsync();
             Assert.That(actual, Is.Not.Empty);
             Assert.That(actual.Count(), Is.EqualTo(stubs.Count()));
         }
@@ -59,13 +59,15 @@ namespace Cosmos.Entity.Mapper.Tests
                 new CollectionQueryableStub { Id = 2, Name = "2" },
                 new CollectionQueryableStub { Id = 3, Name = "3" },
                 new CollectionQueryableStub { Id = 4, Name = "4" },
-            }.AsEnumerable();
+            }.ToList();
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
             var actual = await collectionQueryableMock.Object.FirstOrDefaultAsync();
             Assert.That(actual, Is.Not.Null);
         }
@@ -73,13 +75,15 @@ namespace Cosmos.Entity.Mapper.Tests
         [Test()]
         public async Task FirstOrDefaultAsync_Returns_Null_When_No_Item_Is_In_The_Sequence()
         {
-            var stubs = Enumerable.Empty<CollectionQueryableStub>();
+            var stubs = new List<CollectionQueryableStub>();
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);;
             var actual = await collectionQueryableMock.Object.FirstOrDefaultAsync();
             Assert.That(actual, Is.Null);
         }
@@ -94,9 +98,11 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
             var actual = await collectionQueryableMock.Object.SingleOrDefaultAsync();
             Assert.That(actual, Is.Not.Null);
             Assert.That(actual, Is.EqualTo(stubs.ElementAt(0)));
@@ -106,13 +112,15 @@ namespace Cosmos.Entity.Mapper.Tests
         [Test()]
         public async Task SingleOrDefaultAsync_Can_Return_Null_From_Queryable_When_Sequence_Contains_No_Documents()
         {
-            var stubs = Enumerable.Empty<CollectionQueryableStub>();
+            var stubs = new List<CollectionQueryableStub>();
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
             var actual = await collectionQueryableMock.Object.SingleOrDefaultAsync();
             Assert.That(actual, Is.Null);
         }
@@ -126,9 +134,11 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
             Assert.ThrowsAsync<InvalidOperationException>(() => collectionQueryableMock.Object.SingleOrDefaultAsync());
         }
 
@@ -141,9 +151,12 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
             var actual = await collectionQueryableMock.Object.FirstAsync();
             Assert.That(actual, Is.Not.Null);
             Assert.That(actual, Is.EqualTo(stubs.ElementAt(0)));
@@ -158,9 +171,11 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
             Assert.ThrowsAsync<InvalidOperationException>(() => collectionQueryableMock.Object.FirstAsync());
         }
 
@@ -173,9 +188,12 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
             var actual = await collectionQueryableMock.Object.SingleAsync();
             Assert.That(actual, Is.Not.Null);
             Assert.That(actual, Is.EqualTo(stubs.ElementAt(0)));
@@ -190,9 +208,12 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
             Assert.ThrowsAsync<InvalidOperationException>(() => collectionQueryableMock.Object.SingleAsync());
         }
 
@@ -205,9 +226,12 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+            
             Assert.ThrowsAsync<InvalidOperationException>(() => collectionQueryableMock.Object.SingleAsync());
         }
 
@@ -235,10 +259,13 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
             var actual = await collectionQueryableMock.Object.ToListAsync();
+
             Assert.That(actual, Is.Not.Null);
             Assert.That(actual, Is.Not.Empty);
             Assert.That(actual, Is.InstanceOf<List<CollectionQueryableStub>>());
@@ -254,11 +281,14 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
             var actual = await collectionQueryableMock.Object.AnyAsync();
-            Assert.True(actual);
+            Assert.That(actual, Is.True);
         }
 
         [Test()]
@@ -270,11 +300,14 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
             var actual = await collectionQueryableMock.Object.AnyAsync();
-            Assert.False(actual);
+            Assert.That(actual, Is.False);
         }
 
 
@@ -288,12 +321,36 @@ namespace Cosmos.Entity.Mapper.Tests
 
             var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
             var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
 
             var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
-            collectionQueryableMock.Setup(mock => mock.AsEnumerableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(stubs);
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
             var actual = await collectionQueryableMock.Object.AnyAsync(e => e.Name != null);
-            Assert.True(actual);
+            Assert.That(actual, Is.True);
         }
+
+        [Test()]
+        public async Task AllAsync_Can_Return_False_When_Any_Item_In_The_Sequence_Does_Not_Pass_The_Predicate_In_The_Argument()
+        {
+            var stubs = new Faker<CollectionQueryableStub>()
+                .RuleFor(e => e.Id, e => e.UniqueIndex)
+                .RuleFor(e => e.Name, e => e.Person.FullName)
+                .GenerateBetween(1, 7);
+
+            var queryExecutor = new Mock<IQueryExecutor<CollectionQueryableStub>>();
+            var queryableMock = new Mock<IQueryable<CollectionQueryableStub>>();
+            ConfigureFeedIterator(stubs);
+            queryExecutor.Setup(mock => mock.ExecuteAsync(It.IsAny<Task<FeedResponse<CollectionQueryableStub>>>())).ReturnsAsync(_feedResponseMock.Object);
+
+            var collectionQueryableMock = new Mock<QueryMaterializer<CollectionQueryableStub>>(MockBehavior.Loose, stubs.AsQueryable(), queryExecutor.Object) { CallBase = true };
+            collectionQueryableMock.Setup(mock => mock.ToFeedIterator()).Returns(_feedIteratorMock.Object);
+
+            var actual = await collectionQueryableMock.Object.AllAsync(e => e.Name == "Should not exist");
+            Assert.That(actual, Is.False);
+        }
+
 
         private FeedIterator<CollectionQueryableStub> ConfigureFeedIterator(IEnumerable<CollectionQueryableStub> entities)
         {

--- a/tests/Cosmos.Entity.Mapper.Tests/Validations/SchemaValidationBaseTests.cs
+++ b/tests/Cosmos.Entity.Mapper.Tests/Validations/SchemaValidationBaseTests.cs
@@ -26,7 +26,7 @@ namespace Cosmos.Entity.Mapper.Validations.Tests
         [Test()]
         public void MustHaveKeyDefinitionOrThrow_Returns_True_If_Document_Has_Key_Attribute()
         {
-            Assert.True(SchemaValidationBase<SchemaValidationBaseTestsStubHasSchema>.MustHaveKeyDefinitionOrThrow());
+            Assert.That(SchemaValidationBase<SchemaValidationBaseTestsStubHasSchema>.MustHaveKeyDefinitionOrThrow(), Is.True);
         }
 
         [Test()]
@@ -38,7 +38,7 @@ namespace Cosmos.Entity.Mapper.Validations.Tests
         [Test()]
         public void MustHavePartitionDefinitionOrThrow_Returns_True_If_Document_Has_Partition_Attribute()
         {
-            Assert.True(SchemaValidationBase<SchemaValidationBaseTestsStubHasSchema>.MustHavePartitionDefinitionOrThrow());
+            Assert.That(SchemaValidationBase<SchemaValidationBaseTestsStubHasSchema>.MustHavePartitionDefinitionOrThrow(), Is.True);
         }
 
 


### PR DESCRIPTION
- `AsEmumerableAsync` now returns `IAsyncEnumerable`.
- Previous occurrence of `AsEnumerableAsync` replaced to `ToListAsync`
- Updated test to reflect changes